### PR TITLE
Reflection | `World Cup` IC -> `.reduce` Alt Solution 

### DIFF
--- a/practice_independent_challenges/week3/world_cup/lib/world_cup.rb
+++ b/practice_independent_challenges/week3/world_cup/lib/world_cup.rb
@@ -26,6 +26,7 @@ class WorldCup
   def all_players_by_position
     # To start: add a binding.pry and type self to see what you have access to
 
+    ########## Option 1: BUILDING A HASH
     # we can build a literal hash in the method, but then we call the previous method multiple times:
     # {
     #   "forward" => active_players_by_position("forward"),
@@ -33,7 +34,10 @@ class WorldCup
     #   "defender" => active_players_by_position("defender")
     # }
 
+    ########## Option 2: FASTEST METHOD!
     # Here, we can easily add another position and it leaves the code more dynamic:
+    # op2_start_time = Time.now
+
     positions = ["forward", "midfielder", "defender"]
     players_by_position_hash = Hash.new
 
@@ -42,5 +46,21 @@ class WorldCup
     end
 
     players_by_position_hash
+
+    # opt2_end_time = Time.now - op2_start_time #=> 1.4e-05 (fastest)
+
+    ########## Option 3: USING REDUCE
+    # array = [] #see note below
+    # op3_start_time = Time.now
+
+    # positions = ["forward", "midfielder", "defender"]
+
+    # x = positions.reduce({}) do |accumulator, position| # 2 block variables
+    #   # array << accumulator # used this to examine what .reduce was doing!? replacing previous objects with itself!?
+    #   accumulator[position] = active_players_by_position(position)
+    #   accumulator
+    # end
+    
+  # op3_end_time = Time.now - op3_start_time #=> 1.5e-05 (slower than method above)
   end
 end


### PR DESCRIPTION
Explored alternative solutions to final method in World Cup
Explored inner functionality of `.reduce` by creating an array that shovels in each accumulator
Seems to replace previous objects with itself while also including itself and then reduce must call `.uniq` at the end?

We ran times on the two options and `.reduce` was .1 second slower that the original solution... which over such a small data set (only three soccer position titles) that would make a HUGE difference over larger data sets!

VERY COOL!! 
